### PR TITLE
Update GitHub Actions and GoReleaser versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,9 @@ jobs:
 
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install Go
-      if: success()
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,23 @@ on:
 
 permissions:
   contents: write
-  
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,10 @@ archives:
       - README.md
     format: zip
 
+release:
+  extra_files:
+    - glob: ./dist/homebrew/*.rb
+
 nfpms:
   -
     id: mdviewer-nfpms
@@ -70,7 +74,7 @@ brews:
     repository:
       owner: noborus
       name: homebrew-tap
-      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    skip_upload: true
     commit_author:
       name: noborus
       email: noborusai@gmail.com


### PR DESCRIPTION
- Update GitHub Actions versions for checkout and setup-go to the latest versions.
- Update GoReleaser Action to the latest version.
- Skip uploading Homebrew formula